### PR TITLE
fix highlight & count by hashing author html

### DIFF
--- a/github-lgtm.user.js
+++ b/github-lgtm.user.js
@@ -36,7 +36,7 @@
 	var i = comments.length;
 	while (--i) {
 	    var com = comments[i].getElementsByClassName('comment-body')[0];
-	    var author = comments[i].getElementsByClassName('author').length == 1 ? comments[i].getElementsByClassName('author')[0].innerText : "<none>";
+	    var author = comments[i].getElementsByClassName('author').length == 1 ? comments[i].getElementsByClassName('author')[0] : "<none>";
 	    if (!isNaN(votes[author]) && votes[author] != 0) {
 	        continue;
 	    }


### PR DESCRIPTION
This PR changes highlighting to avoid using innerText.

comments[i].getElementsByClassName('author')[0] would end up putting the following in the votes array:
 on Chrome:
`<a href="/someuser" class="author">someuser</a>`
 on Firefox:
`<a class="someuser" href="/someuser">`

Adding innerText works only on Chrome and it would add "someuser" to the votes array.
